### PR TITLE
Adding methods from Profunctor and Strong to Telescope.

### DIFF
--- a/src/telescope.spec.ts
+++ b/src/telescope.spec.ts
@@ -19,6 +19,40 @@ describe('Telescope', () => {
     t.update(2);
   });
 
+  it('dimap', done => {
+    const divideBy2 = (u: number) => u / 2;
+    const multiplyBy2 = (p: number) => p * 2;
+    const tNat = Telescope.of(2);
+    const tEven = tNat.dimap(multiplyBy2, divideBy2);
+    tEven.stream.pipe(skip(1)).subscribe(next => {
+      expect(next).toBe(2);
+      done();
+    });
+    tNat.update(1);
+  });
+
+  it('uplift with update on source should update first element', done => {
+    const tInt = Telescope.of(1);
+    const tIntString = tInt.uplift<string>('a');
+    tIntString.stream.pipe(skip(1)).subscribe(next => {
+      expect(next.first).toBe(2);
+      expect(next.second).toBe('a');
+      done();
+    });
+    tInt.update(2);
+  });
+
+  it('uplift with update on second element should update all', done => {
+    const tInt = Telescope.of(1);
+    const tIntString = tInt.uplift<string>('a');
+    tIntString.stream.pipe(skip(1)).subscribe(next => {
+      expect(next.first).toBe(2);
+      expect(next.second).toBe('b');
+      done();
+    });
+    tIntString.update({first: 2, second: 'b'});
+  });
+
   it('getter should magnify when given a lens', done => {
     const divideBy2 = (u: number) => u / 2;
     const multiplyBy2 = (p: number, _: number) => p * 2;

--- a/src/telescope.ts
+++ b/src/telescope.ts
@@ -6,6 +6,14 @@ import {Lens} from './lens';
 
 type Evolver<A> = (evolution: Evolution<A>) => void;
 
+interface Pair<A, B> {first: A; second: B; }
+
+/**
+ * A stateful container that exposing a stream of state values that users can subscribe to.
+ *
+ * A Telescope is an endo-profunctor for a type U which means it accepts new U values and
+ * produces U values on the associated stream.
+ */
 export class Telescope<U> {
 
   public static of<U>(initialState: U): Telescope<U> {
@@ -24,6 +32,27 @@ export class Telescope<U> {
 
   constructor(private readonly evolver: Evolver<U>, stream: Observable<U>) {
     this.stream = stream.pipe(distinctUntilChanged());
+  }
+
+  public dimap<P>(to: (u: U) => P, from: (p: P) => U): Telescope<P> {
+    const extend = (evolution: Evolution<P>): Evolution<U> => u => from(evolution(to(u)));
+    return new Telescope<P>(evolution => this.evolver(extend(evolution)),
+      this.stream.pipe(map(to), distinctUntilChanged()),
+    );
+  }
+
+  public uplift<C>(value: C): Telescope<{first: U; second: C; }> {
+    let lastC = value;
+    const to = (u: U) => ({first: u, second: lastC });
+    const extend = (evolution: Evolution<{first: U; second: C; }>): Evolution<U> => u => {
+      const newPair = evolution({first: u, second: lastC});
+      lastC = newPair.second;
+      return newPair.first;
+    };
+
+    return new Telescope<{first: U; second: C; }>(evolution => this.evolver(extend(evolution)),
+      this.stream.pipe(map(to), distinctUntilChanged()),
+    );
   }
 
   public evolve(evolution: Evolution<U>): void {


### PR DESCRIPTION
I think `dimap` can be implemented in terms of `magnify`. I guess we can decide on one or the other.

on `uplift` I was not sure neither about the name nor on the types. It is the equivalent of:

```
second = forAll c => Telescope u -> Telescope (u, c)
```

As we don't have tuples in TS I don't see the point of having both second and first, but I'm not convinced on the names.

Let me know what you think.